### PR TITLE
修改了8.5中关于选择non-dirty page撤回的翻译，并添加了译注

### DIFF
--- a/lec08-page-faults-frans/8.5-demand-paging.md
+++ b/lec08-page-faults-frans/8.5-demand-paging.md
@@ -36,9 +36,9 @@
 
 是的，这是最常用的策略，Least Recently Used，或者叫LRU。除了这个策略之外，还有一些其他的小优化。如果你要撤回一个page，你需要在dirty page和non-dirty page中做选择。dirty page是曾经被写过的page，而non-dirty page是只被读过，但是没有被写过的page。你们会选择哪个来撤回？
 
-> 学生回答：我会选择dirty page，因为它在某个时间点会被重新写回到内存中。
+> 学生回答：我会选择dirty page，因为它在某个时间点需要写入到内存中。
 
-如果dirty page之后再被修改，现在你或许需要对它写两次了（注，一次内存，一次文件），现实中会选择non-dirty page。如果non-dirty page出现在page table1中，你可以将内存page中的内容写到文件中，之后将相应的PTE标记为non-valid，这就完成了所有的工作。之后你可以在另一个page table重复使用这个page。所以通常来说这里优先会选择non-dirty page来撤回。
+你说的对，但现在你或许需要对它写两次了，一旦你写入了它，以后可能会再次修改（译者：根据上下文，老师这里的意思应该是如果选择撤回dirty page，由于此时该页在内存中的内容和硬盘中的内容并不相同了，在撤回的时候，还需要将它写入到硬盘中，而在撤回non-dirty page时，并不需要将其写回硬盘中）。现实中会选择non-dirty page，因为你不需要对它做任何事情。如果non-dirty page出现在page table1中，你只需要将相应的PTE标记为non-valid，这就完成了所有的工作。之后你可以在另一个page table重复使用这个page。所以通常来说这里优先会选择non-dirty page来撤回。
 
 > 学生提问：对于一个cache，我们可以认为它被修改了但是还没有回写到后端存储时是dirty的。那么对于内存page来说，怎么判断dirty？它只存在于内存中，而不存在于其他地方。那么它什么时候会变成dirty呢？
 >


### PR DESCRIPTION
本pr主要包含三部分：
1. 将学生回答和老师的第一句话修改为更加贴近原文；
2. 感觉老师的第一句话有歧义，因此添加了注释；
3. 原翻译中对于non-dirty page撤回的操作有误，将其修改正确。